### PR TITLE
rules_mk: extenal toolchain missing "include/fortify" on using musl libc

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -208,6 +208,9 @@ ifndef DUMP
       ifneq ($(TOOLCHAIN_LIB_DIRS),)
         TARGET_LDFLAGS+= $(patsubst %,-L%,$(TOOLCHAIN_LIB_DIRS))
       endif
+      ifeq ($(CONFIG_USE_MUSL),y)
+        TARGET_CPPFLAGS+= -I$(TOOLCHAIN_DIR)/include/fortify
+      endif
     endif
   endif
 endif


### PR DESCRIPTION
missing include path as following:
-I/xxx/toolchain-aaarch64_cortex-a55+neon-vfpv4_gcc-7.5.0_musl/include/fortify

Co-work: @z80020100

Signed-off-by: v123958 <34919668+v123958@users.noreply.github.com>